### PR TITLE
Attempt to fix the issue of oversized images

### DIFF
--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -29,7 +29,7 @@ layout: compress
 									{% if page.website %}<a href="{{ page.website }}">{% elsif page.source %}<a href="{{ page.source }}">{% endif %}
 										{% if page.images.size > 0 %}
 											<div class="card-header">
-												<img class="mx-auto d-block mw-100" src="{{ page.images[0].url }}" alt="{{ page.images[0].description | default: page.title | escape }}">
+												<img class="mx-auto d-block mw-100 app-image" src="{{ page.images[0].url }}" alt="{{ page.images[0].description | default: page.title | escape }}">
 											</div>
 										{% endif %}
 										<div class="card-body" dir="ltr">
@@ -144,7 +144,7 @@ layout: compress
 												<div class="carousel-inner">
 													{% for img in page.images %}
 														<div class="carousel-item mt-2 mb-2 {% if forloop.first %}active{% endif %}">
-															<img src="{{ img.url }}" class="d-block mx-auto" alt="{{ img.description }}">
+															<img src="{{ img.url }}" class="d-block mx-auto app-image" alt="{{ img.description }}">
 															<div class="carousel-caption d-none d-md-block">
 																<h5 class="carousel-label">{{ img.description }}</h5>
 															</div>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -261,13 +261,6 @@ html[dir=rtl] .navbar-toggler {
 	color: $nav-link-color-hover;
 }
 
-// Make images smaller
-.img-small {
-	max-width: 250px;
-	max-height: 250px;
-}
-
-
 html:not([dir=rtl]) {
 	.btn-back {
 		position: absolute;
@@ -439,8 +432,9 @@ html[dir=rtl] .li-bullet {
 
 // Prevent oversized images in cart pages
 .app-image{
-	max-height:240px;
-	min-height:120px;
+	height:280px;
+	width:auto;
+	object-fit:contain;
 }
 
 // Hide header anchors unless hovering the header

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -437,6 +437,12 @@ html[dir=rtl] .li-bullet {
 	margin-right: 1.5em;
 }
 
+// Prevent oversized images in cart pages
+.app-image{
+	max-height:240px;
+	min-height:120px;
+}
+
 // Hide header anchors unless hovering the header
 .header-anchor {
 	text-decoration: none;


### PR DESCRIPTION
Demo site: <https://testing.snowyhills.xyz>

I've added a new class for images in the cart pages, then added some CSS to prevent them from being bigger than 240px/smaller than 120px. This may not be the best solution, however, it does prevent images in the carousel from taking up the majority of the page. Appears fine on both small and large screens. Some of the smaller images on the site appeear to be unaffected by this change.